### PR TITLE
Fix for new Fixer.IO Endpoint and API key

### DIFF
--- a/FixerSharp.Tests/FixerTests.cs
+++ b/FixerSharp.Tests/FixerTests.cs
@@ -3,88 +3,91 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace FixerSharp.Tests
 {
-    [TestClass]
-    public class FixerTests
-    {
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void Invalid_From_Symbol_Throws_Exception()
-        {
-            Fixer.Convert("ABC", "USD", 100);
-        }
+	[TestClass]
+	public class FixerTests
+	{
+		//Insert your own Fixer.IO API key to see if the tests are working 
+		private static string testApiKey = "00000000000000000000000000000000";
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void Invalid_To_Symbol_ThrowsException()
-        {
-            Fixer.Convert("GBP", "XYZ", 100);
-        }
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentException))]
+		public void Invalid_From_Symbol_Throws_Exception()
+		{
+			Fixer.Convert(testApiKey, "ABC", "USD", 100);
+		}
 
-        [TestMethod]
-        public void Conversion_With_Symbol_Returns_Value()
-        {
-            double converted = Fixer.Convert(Symbols.GBP, Symbols.USD, 100);
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentException))]
+		public void Invalid_To_Symbol_ThrowsException()
+		{
+			Fixer.Convert(testApiKey, "GBP", "XYZ", 100);
+		}
 
-            Assert.AreNotEqual(converted, 0);
-        }
+		[TestMethod]
+		public void Conversion_With_Symbol_Returns_Value()
+		{
+			double converted = Fixer.Convert(testApiKey, Symbols.GBP, Symbols.USD, 100);
 
-        [TestMethod]
-        public void Conversion_With_String_Returns_Value()
-        {
-            double converted = Fixer.Convert("USD", "EUR", 100);
+			Assert.AreNotEqual(converted, 0);
+		}
 
-            Assert.AreNotEqual(converted, 0);
-        }
+		[TestMethod]
+		public void Conversion_With_String_Returns_Value()
+		{
+			double converted = Fixer.Convert(testApiKey, "USD", "EUR", 100);
 
-        [TestMethod]
-        public void Rate_With_Symbol_Returns_Value()
-        {
-            var rate = Fixer.Rate(Symbols.GBP, Symbols.DKK);
+			Assert.AreNotEqual(converted, 0);
+		}
 
-            Assert.AreNotEqual(rate, null);
-        }
+		[TestMethod]
+		public void Rate_With_Symbol_Returns_Value()
+		{
+			var rate = Fixer.Rate(testApiKey, Symbols.GBP, Symbols.DKK);
 
-        [TestMethod]
-        public void Rate_With_Strings_Returns_Value()
-        {
-            var rate = Fixer.Rate("USD", "GBP");
+			Assert.AreNotEqual(rate, null);
+		}
 
-            Assert.AreNotEqual(rate, null);
-        }
+		[TestMethod]
+		public void Rate_With_Strings_Returns_Value()
+		{
+			var rate = Fixer.Rate(testApiKey, "USD", "GBP");
 
-        [TestMethod]
-        public void Rate_Properties_Contain_Data()
-        {
-            var rate = Fixer.Rate(Symbols.GBP, Symbols.EUR);
+			Assert.AreNotEqual(rate, null);
+		}
 
-            Assert.AreNotEqual(rate.From, "");
-            Assert.AreNotEqual(rate.To, "");
-            Assert.AreNotEqual(rate.Rate, 0);
-            Assert.AreNotEqual(rate.Date, default(DateTime));
-        }
+		[TestMethod]
+		public void Rate_Properties_Contain_Data()
+		{
+			var rate = Fixer.Rate(testApiKey, Symbols.GBP, Symbols.EUR);
 
-        [TestMethod]
-        public void Rates_For_Previous_Dates_Contain_Different_Data()
-        {
-            var rate1 = Fixer.Rate(Symbols.GBP, Symbols.EUR, new DateTime(2016, 10, 19));
-            var rate2 = Fixer.Rate(Symbols.GBP, Symbols.EUR, new DateTime(2016, 10, 18));
+			Assert.AreNotEqual(rate.From, "");
+			Assert.AreNotEqual(rate.To, "");
+			Assert.AreNotEqual(rate.Rate, 0);
+			Assert.AreNotEqual(rate.Date, default(DateTime));
+		}
 
-            Assert.AreNotEqual(rate1.Rate, rate2.Rate);
-            Assert.AreNotEqual(rate1.Date, rate2.Date);
-        }
+		[TestMethod]
+		public void Rates_For_Previous_Dates_Contain_Different_Data()
+		{
+			var rate1 = Fixer.Rate(testApiKey, Symbols.GBP, Symbols.EUR, new DateTime(2016, 10, 19));
+			var rate2 = Fixer.Rate(testApiKey, Symbols.GBP, Symbols.EUR, new DateTime(2016, 10, 18));
 
-        [TestMethod]
-        public void Conversion_From_Rate()
-        {
-            var rate = Fixer.Rate(Symbols.EUR, Symbols.GBP);
+			Assert.AreNotEqual(rate1.Rate, rate2.Rate);
+			Assert.AreNotEqual(rate1.Date, rate2.Date);
+		}
 
-            Assert.AreNotEqual(rate.Convert(1), 0);
-            Assert.AreNotEqual(rate.Convert(100), 0);
-            Assert.AreNotEqual(rate.Convert(1000), 0);
-            Assert.AreNotEqual(rate.Convert(10000), 0);
-            Assert.AreNotEqual(rate.Convert(100000), 0);
-            Assert.AreNotEqual(rate.Convert(10000000), 0);
-            Assert.AreNotEqual(rate.Convert(100000000), 0);
-        }
-    }
+		[TestMethod]
+		public void Conversion_From_Rate()
+		{
+			var rate = Fixer.Rate(testApiKey, Symbols.EUR, Symbols.GBP);
+
+			Assert.AreNotEqual(rate.Convert(1), 0);
+			Assert.AreNotEqual(rate.Convert(100), 0);
+			Assert.AreNotEqual(rate.Convert(1000), 0);
+			Assert.AreNotEqual(rate.Convert(10000), 0);
+			Assert.AreNotEqual(rate.Convert(100000), 0);
+			Assert.AreNotEqual(rate.Convert(10000000), 0);
+			Assert.AreNotEqual(rate.Convert(100000000), 0);
+		}
+	}
 }

--- a/FixerSharp/Fixer.cs
+++ b/FixerSharp/Fixer.cs
@@ -1,104 +1,103 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace FixerSharp
 {
-    public class Fixer
-    {
-        private const string BaseUri = "http://api.fixer.io/";
+	public class Fixer
+	{
+		private const string BaseUri = "http://data.fixer.io/api/";
 
-        public static double Convert(string from, string to, double amount, DateTime? date = null)
-        {
-            return GetRate(from, to, date).Convert(amount);
-        }
+		public static double Convert(string apiKey, string from, string to, double amount, DateTime? date = null)
+		{
+			return GetRate(apiKey, from, to, date).Convert(amount);
+		}
 
-        public static async Task<double> ConvertAsync(string from, string to, double amount, DateTime? date = null)
-        {
-            return (await GetRateAsync(from, to, date)).Convert(amount);
-        }
+		public static async Task<double> ConvertAsync(string apiKey, string from, string to, double amount, DateTime? date = null)
+		{
+			return (await GetRateAsync(apiKey, from, to, date)).Convert(amount);
+		}
 
-        public static ExchangeRate Rate(string from, string to, DateTime? date = null)
-        {
-            return GetRate(from, to, date);
-        }
+		public static ExchangeRate Rate(string apiKey, string from, string to, DateTime? date = null)
+		{
+			return GetRate(apiKey, from, to, date);
+		}
 
-        public static async Task<ExchangeRate> RateAsync(string from, string to, DateTime? date = null)
-        {
-            return await GetRateAsync(from, to, date);
-        }
+		public static async Task<ExchangeRate> RateAsync(string apiKey, string from, string to, DateTime? date = null)
+		{
+			return await GetRateAsync(apiKey, from, to, date);
+		}
 
-        private static ExchangeRate GetRate(string from, string to, DateTime? date = null)
-        {
-            from = from.ToUpper();
-            to = to.ToUpper();
+		private static ExchangeRate GetRate(string apiKey, string from, string to, DateTime? date = null)
+		{
+			from = from.ToUpper();
+			to = to.ToUpper();
 
-            if (!Symbols.IsValid(from))
-                throw new ArgumentException("Symbol not found for provided currency", "from");
+			if (!Symbols.IsValid(from))
+				throw new ArgumentException("Symbol not found for provided currency", "from");
 
-            if (!Symbols.IsValid(to))
-                throw new ArgumentException("Symbol not found for provided currency", "to");
+			if (!Symbols.IsValid(to))
+				throw new ArgumentException("Symbol not found for provided currency", "to");
 
-            // Get data from Fixer API
-            var dateString = date.HasValue ? date.Value.ToString("yyyy-MM-dd") : "latest";
-            var url = string.Format("{0}{1}", BaseUri, dateString);
+			var url = GetFixerUrl(apiKey, date);
 
-            using (var client = new HttpClient())
-            {
-                var response = client.GetAsync(url).Result;
-                response.EnsureSuccessStatusCode();
+			using (var client = new HttpClient())
+			{
+				var response = client.GetAsync(url).Result;
+				response.EnsureSuccessStatusCode();
 
-                return ParseData(response.Content.ReadAsStringAsync().Result, from, to);
-            }
-        }
+				return ParseData(response.Content.ReadAsStringAsync().Result, from, to);
+			}
+		}
 
-        private static async Task<ExchangeRate> GetRateAsync(string from, string to, DateTime? date = null)
-        {
-            from = from.ToUpper();
-            to = to.ToUpper();
+		private static async Task<ExchangeRate> GetRateAsync(string apiKey, string from, string to, DateTime? date = null)
+		{
+			from = from.ToUpper();
+			to = to.ToUpper();
 
-            if (!Symbols.IsValid(from))
-                throw new ArgumentException("Symbol not found for provided currency", "from");
+			if (!Symbols.IsValid(from))
+				throw new ArgumentException("Symbol not found for provided currency", "from");
 
-            if (!Symbols.IsValid(to))
-                throw new ArgumentException("Symbol not found for provided currency", "to");
+			if (!Symbols.IsValid(to))
+				throw new ArgumentException("Symbol not found for provided currency", "to");
 
-            // Get data from Fixer API
-            var dateString = date.HasValue ? date.Value.ToString("yyyy-MM-dd") : "latest";
-            var url = string.Format("{0}{1}", BaseUri, dateString);
+			var url = GetFixerUrl(apiKey, date);
 
-            using (var client = new HttpClient())
-            {
-                var response = await client.GetAsync(url);
-                response.EnsureSuccessStatusCode();
+			using (var client = new HttpClient())
+			{
+				var response = await client.GetAsync(url);
+				response.EnsureSuccessStatusCode();
 
-                return ParseData(await response.Content.ReadAsStringAsync(), from, to);
-            }
-        }
+				return ParseData(await response.Content.ReadAsStringAsync(), from, to);
+			}
+		}
 
-        private static ExchangeRate ParseData(string data, string from, string to)
-        {
-            // Parse JSON
-            var root = JObject.Parse(data);
+		private static ExchangeRate ParseData(string data, string from, string to)
+		{
+			// Parse JSON
+			var root = JObject.Parse(data);
 
-            // Exchange base is not included in rates, add this manually
-            var rates = root.Value<JObject>("rates");
-            var baseSymbol = root.Value<string>("base");
-            rates.Add(baseSymbol, 1.00);
+			var rates = root.Value<JObject>("rates");
+			var fromRate = rates.Value<double>(from);
+			var toRate = rates.Value<double>(to);
 
-            var fromRate = rates.Value<double>(from);
-            var toRate = rates.Value<double>(to);
+			var rate = toRate / fromRate;
 
-            var rate = toRate / fromRate;
+			// Parse returned date
+			// Note: This may be different to the requested date as Fixer will return the closest available
+			var returnedDate = DateTime.ParseExact(root.Value<string>("date"), "yyyy-MM-dd",
+				System.Globalization.CultureInfo.InvariantCulture);
 
-            // Parse returned date
-            // Note: This may be different to the requested date as Fixer will return the closest available
-            var returnedDate = DateTime.ParseExact(root.Value<string>("date"), "yyyy-MM-dd",
-                System.Globalization.CultureInfo.InvariantCulture);
+			return new ExchangeRate(from, to, rate, returnedDate);
+		}
 
-            return new ExchangeRate(from, to, rate, returnedDate);
-        }
-    }
+		private static string GetFixerUrl(string apiKey, DateTime? date = null)
+		{
+			var dateString = date.HasValue ? date.Value.ToString("yyyy-MM-dd") : "latest";
+
+			return $"{BaseUri}{dateString}?access_key={apiKey}";
+		}
+
+	}
 }

--- a/FixerSharp/Symbols.cs
+++ b/FixerSharp/Symbols.cs
@@ -1,85 +1,81 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 
 namespace FixerSharp
 {
-    public static class Symbols
-    {
-        public const string AUD = "AUD";
-        public const string BGN = "BGN";
-        public const string BRL = "BRL";
-        public const string CAD = "CAD";
-        public const string CHF = "CHF";
-        public const string CNY = "CNY";
-        public const string CZK = "CZK";
-        public const string DKK = "DKK";
-        public const string EUR = "EUR";
-        public const string GBP = "GBP";
-        public const string HKD = "HKD";
-        public const string HRK = "HRK";
-        public const string HUF = "HUF";
-        public const string IDR = "IDR";
-        public const string ILS = "ILS";
-        public const string INR = "INR";
-        public const string JPY = "JPY";
-        public const string KRW = "KRW";
-        public const string MXN = "MXN";
-        public const string MYR = "MYR";
-        public const string NOK = "NOK";
-        public const string NZD = "NZD";
-        public const string PHP = "PHP";
-        public const string PLN = "PLN";
-        public const string RON = "RON";
-        public const string RUB = "RUB";
-        public const string SEK = "SEK";
-        public const string SGD = "SGD";
-        public const string THB = "THB";
-        public const string TRY = "TRY";
-        public const string USD = "USD";
-        public const string ZAR = "ZAR";
+	public static class Symbols
+	{
+		public const string AUD = "AUD";
+		public const string BGN = "BGN";
+		public const string BRL = "BRL";
+		public const string CAD = "CAD";
+		public const string CHF = "CHF";
+		public const string CNY = "CNY";
+		public const string CZK = "CZK";
+		public const string DKK = "DKK";
+		public const string EUR = "EUR";
+		public const string GBP = "GBP";
+		public const string HKD = "HKD";
+		public const string HRK = "HRK";
+		public const string HUF = "HUF";
+		public const string IDR = "IDR";
+		public const string ILS = "ILS";
+		public const string INR = "INR";
+		public const string JPY = "JPY";
+		public const string KRW = "KRW";
+		public const string MXN = "MXN";
+		public const string MYR = "MYR";
+		public const string NOK = "NOK";
+		public const string NZD = "NZD";
+		public const string PHP = "PHP";
+		public const string PLN = "PLN";
+		public const string RON = "RON";
+		public const string RUB = "RUB";
+		public const string SEK = "SEK";
+		public const string SGD = "SGD";
+		public const string THB = "THB";
+		public const string TRY = "TRY";
+		public const string USD = "USD";
+		public const string ZAR = "ZAR";
 
-        public static bool IsValid(string symbol)
-        {
-            return ValidSymbols.Contains(symbol);
-        }
+		public static bool IsValid(string symbol)
+		{
+			return ValidSymbols.Contains(symbol);
+		}
 
-        private static string[] ValidSymbols = new string[]
-        {
-            AUD,
-            BGN,
-            BRL,
-            CAD,
-            CHF,
-            CNY,
-            CZK,
-            DKK,
-            EUR,
-            GBP,
-            HKD,
-            HRK,
-            HUF,
-            IDR,
-            ILS,
-            INR,
-            JPY,
-            KRW,
-            MXN,
-            MYR,
-            NOK,
-            NZD,
-            PHP,
-            PLN,
-            RON,
-            RUB,
-            SEK,
-            SGD,
-            THB,
-            TRY,
-            USD,
-            ZAR
-        };
-    }
+		private static readonly string[] ValidSymbols = new string[]
+		{
+			AUD,
+			BGN,
+			BRL,
+			CAD,
+			CHF,
+			CNY,
+			CZK,
+			DKK,
+			EUR,
+			GBP,
+			HKD,
+			HRK,
+			HUF,
+			IDR,
+			ILS,
+			INR,
+			JPY,
+			KRW,
+			MXN,
+			MYR,
+			NOK,
+			NZD,
+			PHP,
+			PLN,
+			RON,
+			RUB,
+			SEK,
+			SGD,
+			THB,
+			TRY,
+			USD,
+			ZAR
+		};
+	}
 }


### PR DESCRIPTION
1.- Modified Fixer.IO endpoint to use "http://data.fixer.io/api/" instead of old "http://api.fixer.io/"
2.- Added "apiKey" parameter to Rate and Convert functions to receive new Fixer.IO API key