### PR TITLE
Fix compatibility with new API

### DIFF
--- a/FixerSharp.Tests/FixerTests.cs
+++ b/FixerSharp.Tests/FixerTests.cs
@@ -6,6 +6,9 @@ namespace FixerSharp.Tests
     [TestClass]
     public class FixerTests
     {
+        [TestInitialize]
+        public void TestInitialize() => Fixer.SetApiKey("API_KEY_HERE");
+
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public void Invalid_From_Symbol_Throws_Exception()
@@ -85,6 +88,15 @@ namespace FixerSharp.Tests
             Assert.AreNotEqual(rate.Convert(100000), 0);
             Assert.AreNotEqual(rate.Convert(10000000), 0);
             Assert.AreNotEqual(rate.Convert(100000000), 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Invalid_Api_Key_ThrowsException()
+        {
+            Fixer.SetApiKey(null);
+
+            Fixer.Convert(Symbols.USD, Symbols.EUR, 100);
         }
     }
 }

--- a/FixerSharp/FixerSharp.csproj
+++ b/FixerSharp/FixerSharp.csproj
@@ -10,7 +10,7 @@
     <PackageLicenseUrl>https://github.com/rmorrin/FixerSharp/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/rmorrin/FixerSharp</PackageProjectUrl>
     <PackageTags>currency conversion exchange rate fixer.io</PackageTags>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ Install-Package FixerSharp
 
 ## Usage
 
+### Configure API Access
+
+The fixer.io service now requires an API key for all operations. A free key allowing up to 1000 requests/month can be obtained by registering for a free account on the [fixer.io website](https://fixer.io/signup/free).
+
+Your API key must be configured through the `SetApiKey` method before performing any conversion operations. This should only be required once during application startup (or equivalent):
+
+```
+using FixerSharp;
+
+...
+
+public class Startup
+{
+    ...
+
+    public void Configure(IApplicationBuilder app)
+    {
+        ...
+
+        // One-time call to SetApiKey
+        Fixer.SetApiKey("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    }
+}
+```
+
 ### Convert
 
 Perform a one-off conversion between two currencies:
@@ -24,7 +49,7 @@ using FixerSharp;
 ...
 
 double oneHundredUsdInGbp = Fixer.Convert(Symbols.USD, Symbols.GBP, 100);
-double oneThousandEurInUsd = Fixer.Convert("EUR", "USD", 1000);
+double oneThousandEurInUsd = await Fixer.ConvertAsync("EUR", "USD", 1000);
 ```
 
 ### Exchange Rate
@@ -41,6 +66,11 @@ ExchangeRate rateUsdGbp = Fixer.Rate(Symbols.USD, Symbols.GBP);
 double oneHundredUsdInGbp = rateUsdGbp.Convert(100);
 double oneThousandUsdInGbp = rateUsdGbp.Convert(1000);
 double tenThousandUsdInGbp = rateUsdGbp.Convert(10000);
+
+ExchangeRate rateGbpEur = await Fixer.RateAsync(Symbols.GBP, Symbols.EUR);
+
+double tenGbpInEur = rateGbpEur.Convert(10);
+double oneHundredGbpInEur rateGbpEur.Convert(100);
 ```
 
 *This method is recommended if you have more than one conversion to perform, as data is only retrieved from the fixer API once.*


### PR DESCRIPTION
Raising my own PR for this based on #9, which seems to be inactive now. Updates the package to be compatible with the [new API changes made to fixer.io](https://github.com/fixerAPI/fixer#fixer----important-announcement.)

* Update base uri to the new value
* Add `.SetApiKey("key")` method. This must be set once before attempting any operation.
* Fix broken tests by setting API key before running
* Add new test for an invalid API key